### PR TITLE
Remove sensitive debugging features from ProfileConfigurationFilePersister.java

### DIFF
--- a/src/argouml-app/src/org/argouml/persistence/ProfileConfigurationFilePersister.java
+++ b/src/argouml-app/src/org/argouml/persistence/ProfileConfigurationFilePersister.java
@@ -253,7 +253,7 @@ public class ProfileConfigurationFilePersister extends MemberFilePersister {
 		w.println("</profile>");
 	    }
 	} catch (Exception e) {
-	    e.printStackTrace();
+        LOG.log(Level.SEVERE, "Exception in saveProjectMember", e);
 	    throw new SaveException(e);
 	}
     }


### PR DESCRIPTION
Replaced e.printStackTrace() with LOG.log(...) in ProfileConfigurationFilePersister.java to prevent sensitive information leakage in production.
Closes #14 